### PR TITLE
Code improvement, BIP activation and test values.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -97,6 +97,13 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 0; // Never / undefined
 
+        // Miner White list params
+        consensus.minerWhiteListActivationHeight = 2; //block height that activates the white list.
+        consensus.minerWhiteListAdminPubKey.insert("02627ad4e6382ac1602dde591c43cbb00ead41eaf9f64512ebf442edd5d094aa95"); //pub key required to sign add / remove transactions
+        consensus.minerWhiteListAdminAddress.insert("pTdEMYjKC8KUrF6U9yVHVgqxo7pwxVkqnQ"); //default miner address
+
+
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -185,6 +192,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1462060800; // May 1st 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1493596800; // May 1st 2017
 
+        // Miner White list params
+		consensus.minerWhiteListActivationHeight = 2; //block height that activates the white list.
+		consensus.minerWhiteListAdminPubKey.insert("03f331bdfe024cf106fa1dcedb8b78e084480fa665d91c50b61822d7830c9ea840"); //pub key required to sign add / remove transactions
+		consensus.minerWhiteListAdminAddress.insert("uh2SKjE6R1uw3b5smZ8i1G8rDoQv458Lsj"); //default miner address
+
         pchMessageStart[0] = 0xb1;
 		pchMessageStart[1] = 0xfc;
 		pchMessageStart[2] = 0x50;
@@ -263,6 +275,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 999999999999ULL;
+
+        // Miner White list params
+		consensus.minerWhiteListActivationHeight = 2; //block height that activates the white list.
+		consensus.minerWhiteListAdminPubKey.insert("03760087582c5e225aea2a6781f4df8b12d7124e4f039fbd3e6d053fdcaacc60eb"); //pub key required to sign add / remove transactions
+		consensus.minerWhiteListAdminAddress.insert("ucNbB1K3BaHWY5tXrWiyWn11QB51vPDuVE"); //default miner address
 
         pchMessageStart[0] = 0x35;
 		pchMessageStart[1] = 0xb2;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -74,7 +74,7 @@ public:
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;
-        /* IoP beta change - BIP34 disabled because we can't allow version 2 blocks since we used the coinbase scriptsig for the miner white list */
+        /* IoP beta change - BIP30 being enforced since beginning */
         consensus.BIP34Height = -1;
         consensus.BIP34Hash = uint256();
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -170,7 +170,7 @@ public:
         consensus.nMajorityEnforceBlockUpgrade = 51;
         consensus.nMajorityRejectBlockOutdated = 75;
         consensus.nMajorityWindow = 100;
-        /* IoP beta change - BIP34 disabled because we can't allow version 2 blocks since we used the coinbase scriptsig for the miner white list */
+        /* IoP beta change - BIP30 being enforced since beginning */
         consensus.BIP34Height = -1;
         consensus.BIP34Hash = uint256();
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -74,8 +74,9 @@ public:
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;
-        consensus.BIP34Height = 227931;
-        consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
+        /* IoP beta change - BIP34 disabled because we can't allow version 2 blocks since we used the coinbase scriptsig for the miner white list */
+        consensus.BIP34Height = -1;
+        consensus.BIP34Hash = uint256();
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -169,8 +170,9 @@ public:
         consensus.nMajorityEnforceBlockUpgrade = 51;
         consensus.nMajorityRejectBlockOutdated = 75;
         consensus.nMajorityWindow = 100;
-        consensus.BIP34Height = 21111;
-        consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
+        /* IoP beta change - BIP34 disabled because we can't allow version 2 blocks since we used the coinbase scriptsig for the miner white list */
+        consensus.BIP34Height = -1;
+        consensus.BIP34Hash = uint256();
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -17,7 +17,7 @@ static const unsigned int MAX_BLOCK_BASE_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
-static const int COINBASE_MATURITY = 100;
+static const int COINBASE_MATURITY = 1; // Rodrigo temp fix to speed up test in MainNet
 
 /** Flags for nSequence and nLockTime locks */
 enum {

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -8,6 +8,7 @@
 
 #include "uint256.h"
 #include <map>
+#include <set>
 #include <string>
 
 namespace Consensus {
@@ -61,6 +62,11 @@ struct Params {
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
+
+    /* IoP beta release - Miner White List params */
+    int minerWhiteListActivationHeight;
+    std::set<std::string> minerWhiteListAdminPubKey;
+    std::set<std::string> minerWhiteListAdminAddress;
 };
 } // namespace Consensus
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2561,7 +2561,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     hashPrevBestCoinBase = block.vtx[0].GetHash();
 
     /* IoP beta release - added window activation for WhiteList control */
-    if (pindex->nHeight > 105){
+    if (pindex->nHeight > 110){
 		LogPrint("MinersWhiteList", "Miners white list control activated.\n");
 		fIsMinerWhiteList = true;
 	} else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2561,19 +2561,14 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     hashPrevBestCoinBase = block.vtx[0].GetHash();
 
     /* IoP beta release - added window activation for WhiteList control */
-    if (pindex->nHeight > 110){
+    int minerWhiteListActivationHeight = Params().GetConsensus().minerWhiteListActivationHeight;
+    if (pindex->nHeight > minerWhiteListActivationHeight){
 		LogPrint("MinersWhiteList", "Miners white list control activated.\n");
 		fIsMinerWhiteList = true;
 	} else {
 		LogPrint("MinersWhiteList", "Miners white list control deactivated.\n");
 		fIsMinerWhiteList = false;
 	}
-
-    /* IoP beta release - added a list of public keys that are valid to detect miner white list transactions. */
-    std::set<std::string> masterValidMiners {
-    	"03760087582c5e225aea2a6781f4df8b12d7124e4f039fbd3e6d053fdcaacc60eb", //regTest
-		"03f331bdfe024cf106fa1dcedb8b78e084480fa665d91c50b61822d7830c9ea840", //testnet
-		"02627ad4e6382ac1602dde591c43cbb00ead41eaf9f64512ebf442edd5d094aa95"}; //mainnet
 
     /* IoP beta release - we track non cb transaction to identify transactions that add or remove miner addresses into the blockchain */
     BOOST_FOREACH(const CTransaction& tx, block.vtx) {
@@ -2591,7 +2586,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 				std::string pkey = HexStr(value);
 
 				// this transaction has been identified as a white miner list transaction.
-				if (masterValidMiners.count(pkey)){
+				if (Params().GetConsensus().minerWhiteListAdminPubKey.count(pkey)){
 					LogPrint("MinerWhiteListTransaction", "Miner White List Transaction detected: %s \n", tx.ToString());
 
 					//flag that will store the action to perform

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3724,16 +3724,21 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
         }
     }
 
-    // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
-    // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
-    if (block.nVersion >= 2 && IsSuperMajority(2, pindexPrev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams))
-    {
-        CScript expect = CScript() << nHeight;
-        if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||
-            !std::equal(expect.begin(), expect.end(), block.vtx[0].vin[0].scriptSig.begin())) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-cb-height", false, "block height mismatch in coinbase");
-        }
+
+    /* IoP beta change - we are only enforcing BIP32 with height in coinbase ScriptSig if Miner whitelist is not active */
+    if (!fIsMinerWhiteList){
+    	// Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
+    	// if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
+    	if (block.nVersion >= 2 && IsSuperMajority(2, pindexPrev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams))
+		{
+			CScript expect = CScript() << nHeight;
+			if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||
+				!std::equal(expect.begin(), expect.end(), block.vtx[0].vin[0].scriptSig.begin())) {
+				return state.DoS(100, false, REJECT_INVALID, "bad-cb-height", false, "block height mismatch in coinbase");
+			}
+		}
     }
+
 
     // Validation for witness commitments.
     // * We compute the witness hash (which is the hash including witnesses) of all the block's transactions, except the

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1715,8 +1715,8 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 	if (nHeight == 1)
 		nSubsidy = 2100000 * COIN;
 	else
-		if (nHeight > 105)
-			nSubsidy = 1 * COIN;
+		if (nHeight > 1)
+			nSubsidy = 1 * COIN; //this code line to be removed after beta release. We are forcing 1 IoP per block during this phase.
 		else
 			nSubsidy = 50 * COIN;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3725,7 +3725,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     }
 
 
-    /* IoP beta change - we are only enforcing BIP32 with height in coinbase ScriptSig if Miner whitelist is not active */
+    /* IoP beta change - we are only enforcing BIP34 with height in coinbase ScriptSig if Miner whitelist is not active */
     if (!fIsMinerWhiteList){
     	// Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
     	// if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):

--- a/src/minerwhitelist.cpp
+++ b/src/minerwhitelist.cpp
@@ -8,6 +8,7 @@
 #include "hash.h"
 #include "clientversion.h"
 #include "chainparams.h"
+#include "consensus/consensus.h"
 #include "minerwhitelist.h"
 #include "random.h"
 #include "serialize.h"
@@ -70,9 +71,15 @@ minerwhitelist_v CMinerWhiteList::Read() {
 		//return error("%s: Serialize or I/O error - %s", __func__, e.what());
 	}
 
-	// if there are no miners on the list, we are hardcoding the Mainnet admin address which can always mine
-	if (pkeys.empty())
-		pkeys.push_back("pTdEMYjKC8KUrF6U9yVHVgqxo7pwxVkqnQ");
+	// if there are no miners on the list, we are adding the default admin address
+	if (pkeys.empty()){
+		std::set<std::string> minerWhiteListAdminAddress = Params().GetConsensus().minerWhiteListAdminAddress;
+		set<string>::iterator it;
+		for (it = minerWhiteListAdminAddress.begin(); it != minerWhiteListAdminAddress.end(); it++){
+			pkeys.push_back(*it);
+		}
+	}
+
 
 	return pkeys;
 }

--- a/src/minerwhitelist.cpp
+++ b/src/minerwhitelist.cpp
@@ -70,6 +70,10 @@ minerwhitelist_v CMinerWhiteList::Read() {
 		//return error("%s: Serialize or I/O error - %s", __func__, e.what());
 	}
 
+	// if there are no miners on the list, we are hardcoding the Mainnet admin address which can always mine
+	if (pkeys.empty())
+		pkeys.push_back("pTdEMYjKC8KUrF6U9yVHVgqxo7pwxVkqnQ");
+
 	return pkeys;
 }
 


### PR DESCRIPTION
* I  improved the way we deal with whitelist parameters by moving them to the params class divided by network type.
* to be able to use them sooner while we are testing, the coinbase coins are spendable since 1 block instead of 100. We will revert this later. 
* the minerWhiteList activation windows also start at block 1 so we can test it sooner tomorrow. we will revert this later to block 110 for example.
* a default miner is allowed to mine always to avoid missing the window activation as we did today, it doesn't matter if the control is already active or not, the admin will always be able to mine blocks.

* I'm including an important change: the enforcement of BIPS 30 and 34 since block 0 and a change in BIP 34 logic also.

BIP 30 is to avoid duplicated coinbase transactions. We are ok with this so we are enforcing it right from the beggining. Our own miner will always generate unique coinbase transaction by adding the op_return with random data.

We are changing BIP 34 by avoiding the enforcement of putting the height in the coinbase scriptSig while our whitelist control is activated, because we are putting instead the signature and the public key. 

Without these changes that I have uploaded, the BIP 34 control would be triggered at block 750 forcing us to fork it in the future because our blocks would not be valid.

I have tested now that we are ok to generate all blocks without problems.