### PR TITLE
Build instructions for Mac OS X

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ Installing IoP Client
 At this early stage we don't provide other packages than for Ubuntu Linux.
 But you can find other community packages on the [community repositories](http://repo.fermat.community)
 
-For help building IoP Core on OSX see [INSTALL_OSX.md](http://github.com/Fermat-ORG/iop-blockchain/INSTALL_OSX.md)
+For help building IoP Core on OSX see [INSTALL_OSX.md](https://github.com/Anfauglith/iop-blockchain/blob/beta-1.0.0/INSTALL_OSX.md)
 
 We will provide Windows, MacOSX and other Packages after the beta phase, please be patient.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,6 +4,8 @@ Installing IoP Client
 At this early stage we don't provide other packages than for Ubuntu Linux.
 But you can find other community packages on the [community repositories](http://repo.fermat.community)
 
+For help building IoP Core on OSX see [INSTALL_OSX.md](http://github.com/Fermat-ORG/iop-blockchain/INSTALL_OSX.md)
+
 We will provide Windows, MacOSX and other Packages after the beta phase, please be patient.
 
 # Installing Ubuntu Packages
@@ -116,4 +118,3 @@ Until we have official documentation you can follow the Fermat IoP Wallet Guide:
 [English](http://repo.fermat.community/Fermat_Wallet_Tutorial/FermatWalletTutorialEN.html)
 
 [Spanish](https://docs.google.com/document/d/1_RkGVSKEz42Sh9NgGdt9WKrKcvi6jhdhtlxxHqgpZxA)
-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ Installing IoP Client
 At this early stage we don't provide other packages than for Ubuntu Linux.
 But you can find other community packages on the [community repositories](http://repo.fermat.community)
 
-For help building IoP Core on OSX see [INSTALL_OSX.md](https://github.com/Anfauglith/iop-blockchain/blob/beta-1.0.0/INSTALL_OSX.md)
+For a little help building IoP Core on OSX see [INSTALL_OSX.md](https://github.com/Anfauglith/iop-blockchain/blob/beta-1.0.0/INSTALL_OSX.md)
 
 We will provide Windows, MacOSX and other Packages after the beta phase, please be patient.
 

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -16,17 +16,17 @@ and extract. Move the .app file to your Applications folder. Your wallet and all
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 3. Install dependencies with
- ```
- brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 libevent qt5
- ``` 
+```
+brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 libevent qt5
+``` 
 This will take a while. WARNING: For macOS 10.12 users, see below.
 4. Use the command line to clone the git repository to your favorite location with 
 ```
-git clone https://github.com/Anfauglith/iop-blockchain.git /path/to/favorite/location
+git clone https://github.com/Fermat-ORG/iop-blockchain.git /path/to/favorite/location
 ```
 e.g. 
 ```
-git clone https://github.com/Anfauglith/iop-blockchain.git ~/GitHub/iop-blockchain
+git clone https://github.com/Fermat-ORG/iop-blockchain.git ~/GitHub/iop-blockchain
 ```
 5. Change to this location using `cd ~/GitHub/iop-blockchain` or equivalent.
 

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -9,18 +9,18 @@ and extract. Move the .app file to your Applications folder. Your wallet and all
 
 #Building IoP Core on Mac
 
-1. Install the latest XCode Package from the Mac App Store (Command Line Tools are not sufficient).
+* Install the latest XCode Package from the Mac App Store (Command Line Tools are not sufficient).
 
-2. Install homebrew (http://brew.sh) via the command prompt with
+* Install homebrew (http://brew.sh) via the command prompt with
 ```
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
-3. Install dependencies with
+* Install dependencies with
 ```
 brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 libevent qt5
 ``` 
 This will take a while. WARNING: For macOS 10.12 users, see below.
-4. Use the command line to clone the git repository to your favorite location with 
+* Use the command line to clone the git repository to your favorite location with 
 ```
 git clone https://github.com/Fermat-ORG/iop-blockchain.git /path/to/favorite/location
 ```
@@ -28,18 +28,21 @@ e.g.
 ```
 git clone https://github.com/Fermat-ORG/iop-blockchain.git ~/GitHub/iop-blockchain
 ```
-5. Change to this location using `cd ~/GitHub/iop-blockchain` or equivalent.
+* Change to this location using `cd ~/GitHub/iop-blockchain` or equivalent.
 
-6. Run `./autogen.sh`
+* Run `./autogen.sh`
 
-7. Run `./configure`. Ignore the warnings about deprecated functions for now.
+* Run `./configure`. Ignore the warnings about deprecated functions for now.
 
-8. Run `make && make deploy`
+* Run `make && make deploy`
 
-9. Move the .app to your Applications Folder with `mv ./IoP-Qt.app /Applications/`
+* Move the .app to your Applications Folder with `mv ./IoP-Qt.app /Applications/`
 
+* Your wallet and all data will be stored in `~/Library/Application Support/IoP/`. To backup your wallet, copy 
+`~/Library/Application Support/IoP/wallet.dat` to a secure location. 
 
-WARNING: If you are on macOS 10.12, qt5 is broken and will not `brew install`. To work around this, open `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5.rb` and add 
+# WARNING
+If you are on macOS 10.12, qt5 is broken and will not `brew install`. To work around this, open `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5.rb` and add 
 
 ```
 -skip qtconnectivity

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -1,0 +1,53 @@
+#Installing IoP Core on OS X
+
+Download the binary file from `http://link.here`
+and extract. Move the .app file to your Applications folder. Your wallet and all data will be stored in `~/Library/Application Support/IoP/`. To backup your wallet, copy 
+`~/Library/Application Support/IoP/wallet.dat` to a secure location.
+
+#Building IoP Core on Mac
+
+1. Install the latest XCode Package from the Mac App Store (Command Line Tools are not sufficient).
+
+2. Install homebrew (http://brew.sh) via the command prompt with
+```/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+3. Install dependencies with 
+`brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 libevent qt5` 
+This will take a while. WARNING: For macOS 10.12 users, see below.
+4. Use the command line to clone the git repository to your favorite location with `git clone https://github.com/Anfauglith/iop-blockchain.git /path/to/favorite/location`, e.g. `git clone https://github.com/Anfauglith/iop-blockchain.git ~/GitHub/iop-blockchain`
+
+5. Change to this location using `cd ~/GitHub/iop-blockchain` or equivalent.
+
+6. Run `./autogen.sh`
+
+7. Run `./configure`. Ignore the warnings about deprecated functions for now.
+
+8. Run `make && make deploy`
+
+9. Move the .app to your Applications Folder with `mv ./IoP-Qt.app /Applications/`
+
+
+WARNING: If you are on macOS 10.12, qt5 is broken and will not `brew install`. To work around this, open `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5.rb` and add 
+
+```-skip qtconnectivity
+-skip qtwebengine
+-skip qtwebview```
+
+to the end of the lists of arguments here (should be line 80-96)
+
+```def install
+    args = %W[
+      -verbose
+      -prefix #{prefix}
+      -release
+      -opensource -confirm-license
+      -system-zlib
+      -qt-libpng
+      -qt-libjpeg
+      -qt-freetype
+      -qt-pcre
+      -nomake tests
+      -no-rpath
+      ]```
+
+Then save and close. Continue as normal.

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -1,11 +1,11 @@
-#Installing IoP Core on OS X
+<!-- #Installing IoP Core on OS X
 
 Download the binary file from 
 ```
 http://link.here
 ```
 and extract. Move the .app file to your Applications folder. Your wallet and all data will be stored in `~/Library/Application Support/IoP/`. To backup your wallet, copy 
-`~/Library/Application Support/IoP/wallet.dat` to a secure location.
+`~/Library/Application Support/IoP/wallet.dat` to a secure location. -->
 
 #Building IoP Core on Mac
 

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -9,7 +9,7 @@ and extract. Move the .app file to your Applications folder. Your wallet and all
 
 #Building IoP Core on Mac
 
-* Install the latest XCode Package from the Mac App Store (Command Line Tools are not sufficient).
+* Install the latest XCode Package from the Mac App Store (Command Line Tools are not sufficient) and run it.
 
 * Install homebrew (http://brew.sh) via the command prompt with
 ```

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -1,6 +1,9 @@
 #Installing IoP Core on OS X
 
-Download the binary file from `http://link.here`
+Download the binary file from 
+```
+http://link.here
+```
 and extract. Move the .app file to your Applications folder. Your wallet and all data will be stored in `~/Library/Application Support/IoP/`. To backup your wallet, copy 
 `~/Library/Application Support/IoP/wallet.dat` to a secure location.
 
@@ -9,12 +12,22 @@ and extract. Move the .app file to your Applications folder. Your wallet and all
 1. Install the latest XCode Package from the Mac App Store (Command Line Tools are not sufficient).
 
 2. Install homebrew (http://brew.sh) via the command prompt with
-`/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
-3. Install dependencies with 
-`brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 libevent qt5` 
+```
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+3. Install dependencies with
+ ```
+ brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 libevent qt5
+ ``` 
 This will take a while. WARNING: For macOS 10.12 users, see below.
-4. Use the command line to clone the git repository to your favorite location with `git clone https://github.com/Anfauglith/iop-blockchain.git /path/to/favorite/location`, e.g. `git clone https://github.com/Anfauglith/iop-blockchain.git ~/GitHub/iop-blockchain`
-
+4. Use the command line to clone the git repository to your favorite location with 
+```
+git clone https://github.com/Anfauglith/iop-blockchain.git /path/to/favorite/location
+```
+e.g. 
+```
+git clone https://github.com/Anfauglith/iop-blockchain.git ~/GitHub/iop-blockchain
+```
 5. Change to this location using `cd ~/GitHub/iop-blockchain` or equivalent.
 
 6. Run `./autogen.sh`
@@ -28,13 +41,16 @@ This will take a while. WARNING: For macOS 10.12 users, see below.
 
 WARNING: If you are on macOS 10.12, qt5 is broken and will not `brew install`. To work around this, open `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5.rb` and add 
 
-```-skip qtconnectivity
+```
+-skip qtconnectivity
 -skip qtwebengine
--skip qtwebview```
+-skip qtwebview
+```
 
 to the end of the lists of arguments here (should be line 80-96)
 
-```def install
+```
+def install
     args = %W[
       -verbose
       -prefix #{prefix}
@@ -47,6 +63,7 @@ to the end of the lists of arguments here (should be line 80-96)
       -qt-pcre
       -nomake tests
       -no-rpath
-      ]```
+      ]
+```
 
 Then save and close. Continue as normal.

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -9,8 +9,7 @@ and extract. Move the .app file to your Applications folder. Your wallet and all
 1. Install the latest XCode Package from the Mac App Store (Command Line Tools are not sufficient).
 
 2. Install homebrew (http://brew.sh) via the command prompt with
-```/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-```
+`/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 3. Install dependencies with 
 `brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 libevent qt5` 
 This will take a while. WARNING: For macOS 10.12 users, see below.

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -42,7 +42,7 @@ git clone https://github.com/Fermat-ORG/iop-blockchain.git ~/GitHub/iop-blockcha
 `~/Library/Application Support/IoP/wallet.dat` to a secure location. 
 
 # WARNING
-If you are on macOS 10.12, qt5 is broken and will not `brew install`. To work around this, open `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5.rb` and add 
+If you are on macOS 10.12, qt5 is broken and as of today (2016/10/06) will not `brew install`. To work around this, open `/usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/qt5.rb` and add 
 
 ```
 -skip qtconnectivity
@@ -69,4 +69,4 @@ def install
       ]
 ```
 
-Then save and close. Continue as normal.
+Then save and close. Continue as normal. Thanks for this solution to user [UdjinM6](https://github.com/UdjinM6), who posted this [here](https://github.com/Homebrew/homebrew-core/issues/4841#issuecomment-249177609).


### PR DESCRIPTION
I added a little help for building the client on Mac OS X. I hope the wording is alright. 

Also: The Icons built into the .app package are still the bitcoin ones (`share/pixmaps/`). Maybe they need to be packaged into an `IoP.icns` file and put at `src/qt/res/icons/` manually.